### PR TITLE
prevented 3D panel from triggering window resize event

### DIFF
--- a/src/css/mutation_3d.css
+++ b/src/css/mutation_3d.css
@@ -35,7 +35,7 @@
  * 3D visualizer panel
  */
 .mutation-3d-container {
-	width: 400px;
+	width: 430px;
 	font-family: verdana, arial, sans-serif;
 	font-size: 12px;
 	position: fixed;
@@ -157,7 +157,7 @@
 	height: 24px;
 }
 .mutation-3d-mutation-style-menu input,
-.mutation-3d-protein-style-menu input,
+.mutation-3d-protein-style-menu input
 {
 	margin: 0;
 }

--- a/src/js/component/Mutation3dVis.js
+++ b/src/js/component/Mutation3dVis.js
@@ -539,6 +539,14 @@ function Mutation3dVis(name, options)
 		_3dApp.script(script);
 	}
 
+	function resizeViewer()
+	{
+		if (_3dApp.getViewer)
+		{
+			_3dApp.getViewer().resize();
+		}
+	}
+
 	/**
 	 * Focuses on the residue corresponding to the given pileup. If there is
 	 * no corresponding residue for the given pileup, this function does not
@@ -883,6 +891,7 @@ function Mutation3dVis(name, options)
 		isVisible: isVisible,
 		reload: reload,
 		refresh: refresh,
+		resizeViewer: resizeViewer,
 		focusOn: focus,
 		center: centerOnHighlighted,
 		resetCenter: resetCenter,

--- a/src/js/view/Mutation3dVisView.js
+++ b/src/js/view/Mutation3dVisView.js
@@ -163,6 +163,7 @@ var Mutation3dVisView = Backbone.View.extend({
 		// make the container resizable
 		container3d.resizable({
 			alsoResize: ".mutation-3d-vis-container,.mutation-3d-vis-container div:eq(0)",
+			//alsoResize: ".mutation-3d-vis-container",
 			handles: "sw, s, w",
 			minWidth: 400,
 			minHeight: 300,
@@ -179,7 +180,19 @@ var Mutation3dVisView = Backbone.View.extend({
 
 				// a workaround to prevent position to be set to absolute
 				container3d.css("position", "fixed");
+			},
+			resize: function(event, ui) {
+				// this is to prevent window resize event to trigger
+				event.stopPropagation();
+
+				// resize (redraw) the 3D viewer
+				// (since we don't propagate resize event up to window anymore)
+				mut3dVis.resizeViewer();
 			}
+		})
+		.on('resize', function(event) {
+			// this is to prevent window resize event to trigger
+			event.stopPropagation();
 		});
 	},
 	/**


### PR DESCRIPTION
This prevents mutation table from re-rendering itself after each 3D panel resize event.
