### PR TITLE
fixed jquery resizable and bootstrap conflict for the 3D panel

### DIFF
--- a/src/css/mutation_3d.css
+++ b/src/css/mutation_3d.css
@@ -50,6 +50,8 @@
 	padding: 5px 10px 10px;
 	-moz-border-radius: 15px;
 	-webkit-border-radius: 15px;
+	/* fix for bootstrap 3 */
+	box-sizing: content-box;
 }
 .mutation-3d-vis-header {
 	padding-bottom: 5px;


### PR DESCRIPTION
This fixes the "jumpy" behavior of the 3D panel when the latest bootstrap css is included.

See http://stackoverflow.com/questions/24607929/jquery-ui-resizable-bootstrap-conflict for more details.
